### PR TITLE
Buildings on nodes

### DIFF
--- a/HOT-Validate.mapcss
+++ b/HOT-Validate.mapcss
@@ -13,7 +13,7 @@ meta
 	title: "HOT-Validate";
 	description: "This Style is designed for HOT Validators for use in JOSM. More Info at https://github.com/MarkCupitt/HOT-Osm-Validation";
 	author: "MarkCupitt";
-	version: "1.0.21_2014-11-24";
+	version: "1.0.22_2017-02-16";
 
 }
 
@@ -133,6 +133,27 @@ node:unconnected
 	symbol-stroke-opacity: 1.0;
 }
 
+
+*/
+
+/* -------------------------------------------------------
+          Any Building tag on a Node (instead of way)
+--------------------------------------------------------*/
+node[building]
+{
+    color: red;
+    fill-color: red;
+    fill-opacity: 0.7;
+    symbol-shape: octagon;
+    symbol-size: 50;
+
+    symbol-fill-color: Red;
+    symbol-fill-opacity: 0.6;
+
+    symbol-stroke-color: black;
+    symbol-stroke-opacity: 0.7;
+    icon-image: none;
+}
 
 
 /* -------------------------------------------------------

--- a/HOT-Validate.mapcss
+++ b/HOT-Validate.mapcss
@@ -14,7 +14,6 @@ meta
 	description: "This Style is designed for HOT Validators for use in JOSM. More Info at https://github.com/MarkCupitt/HOT-Osm-Validation";
 	author: "MarkCupitt";
 	version: "1.0.22_2017-02-16";
-
 }
 
 
@@ -137,7 +136,7 @@ node:unconnected
 */
 
 /* -------------------------------------------------------
-          Any Building tag on a Node (instead of way)
+          Any "Building" node - buildings should be ways
 --------------------------------------------------------*/
 node[building]
 {
@@ -152,7 +151,7 @@ node[building]
 
     symbol-stroke-color: black;
     symbol-stroke-opacity: 0.7;
-    icon-image: none;
+    icon-image: none; /* needed so that default styles are overridden */
 }
 
 


### PR DESCRIPTION
Hello, here's another validation rule that would be useful:
OSM buildings are supposed to be (closed) ways; however, some users mistakenly mark them as a node and tag that. This addition makes such probably-mistaken edits stand out.